### PR TITLE
people: Sort profiles in alumni sections by graduation year in reverse

### DIFF
--- a/layouts/section/people.html
+++ b/layouts/section/people.html
@@ -8,12 +8,17 @@
       {{- range $role := .Site.Params.people.roles }}
         {{- $pages := where $.Pages "Params.role" $role.id }}
         {{- if $pages }}
-        <h1>{{ $role.plural }}</h1>
-        <ul class="people">
-        {{- range sort (sort $pages "Params.name") "Params.yearjoined" }}
-        {{ .Render "li" }}
-        {{- end }}
-        </ul>
+          <h1>{{ $role.plural }}</h1>
+          <ul class="people">
+          {{- $pages = sort $pages "Params.name" }}
+          {{- $pages = sort $pages "Params.yearjoined" }}
+          {{- if hasPrefix $role.id "alumnus" }}
+            {{- $pages = sort $pages "Params.yeargraduated" "desc" }}
+          {{- end }}
+          {{- range $pages }}
+            {{ .Render "li" }}
+          {{- end }}
+          </ul>
         {{- end }}
       {{- end }}
       {{ .Content }}


### PR DESCRIPTION
Make profile cards sorting order uniform across all role sections to
address #22. Namely, in each section, put people who are expected
to graduate or have graduated earlier before those who are expected
to graduate or have graduated later.

The former corresponds to sorting by the `yearjoined` field in
ascending order, and the latter corresponds to additionally sorting by
the `yeargraduated` field in descending order for entries in each of
the alumni sections.