### PR TITLE
Link personal pages of known authors from bibliography entries

### DIFF
--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -7,11 +7,11 @@
   {{- $haseditor := index .entry "editor" | default slice -}}
   {{- if $hasauthor -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" .entry.author "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" .entry.author "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- else if $haseditor -}}
     <span class="editors">
-      {{- partial "bib/names.html" (dict "names" .entry.editor "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" .entry.editor "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
     {{- if gt (len .entry.editor) 1 }}{{ "Eds" }}{{ else }}{{ "Ed" }}{{ end }}{{ "., " -}}
   {{- end -}}
@@ -20,7 +20,7 @@
   {{- with .entry.series }}{{ ", " }}<span class="series">ser.&nbsp;{{ . }}</span>{{ end -}}
   {{- if and $hasauthor $haseditor -}}
     {{ ", " }}<span class="editors">
-      {{- partial "bib/names.html" (dict "names" .entry.editor "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" .entry.editor "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
     {{- if gt (len .entry.editor) 1 }}{{ "Eds" }}{{ else }}{{ "Ed" }}{{ end -}}
   {{- end -}}
@@ -36,11 +36,11 @@
   {{- $haseditor := index .entry "editor" | default slice -}}
   {{- if $hasauthor -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" .entry.author "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" .entry.author "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- else if $haseditor -}}
     <span class="editors">
-      {{- partial "bib/names.html" (dict "names" .entry.editor "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" .entry.editor "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
     {{- if gt (len .entry.editor) 1 }}{{ "Eds" }}{{ else }}{{ "Ed" }}{{ end }}{{ "., " -}}
   {{- end -}}
@@ -59,7 +59,7 @@
 {{- else if eq .entry.kind "incollection" -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}
@@ -68,7 +68,7 @@
   {{- with .entry.series }}{{ ", " }}<span class="series">ser.&nbsp;{{ . }}</span>{{ end -}}
   {{- with .entry.editor -}}
     {{ ", " }}<span class="editors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
     {{- if gt (len .) 1 }}{{ "Eds" }}{{ else }}{{ "Ed" }}{{ end -}}
   {{- end -}}
@@ -84,7 +84,7 @@
 {{- else if eq .entry.kind "article" -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}
@@ -98,7 +98,7 @@
 {{- else if or (eq .entry.kind "inproceedings") (eq .entry.kind "conference") -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}
@@ -109,7 +109,7 @@
   {{- with .entry.series }}{{ ", " }}<span class="series">ser.&nbsp;{{ . }}</span>{{ end -}}
   {{- with .entry.editor -}}
     {{- ", " }}<span class="editors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
     {{- if gt (len .) 1 }}{{ "Eds." }}{{ else }}{{ "Ed." }}{{ end -}}
   {{- end -}}
@@ -132,7 +132,7 @@
 {{- else if eq .entry.kind "proceedings" -}}
   {{- with .entry.editor -}}
     {{- ", " }}<span class="editors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
     {{- if gt (len .) 1 }}{{ "Eds." }}{{ else }}{{ "Ed." }}{{ end -}}
   {{- end -}}
@@ -154,7 +154,7 @@
 {{- else if eq .entry.kind "techreport" -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}
@@ -168,7 +168,7 @@
   {{- $isphd := eq .entry.kind "phdthesis" -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}
@@ -180,7 +180,7 @@
 {{- else if in (slice "misc" "manual" "booklet") .entry.kind -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}
@@ -198,7 +198,7 @@
 {{- else if eq .entry.kind "unpublished" -}}
   {{- with .entry.author -}}
     <span class="authors">
-      {{- partial "bib/names.html" (dict "names" . "params" $.params) -}}
+      {{- partial "bib/names.html" (dict "names" . "params" $.params "peoplepages" $.peoplepages) -}}
     </span>{{ ", " -}}
   {{- end -}}
   {{- with .entry.title }}{{ partial "bib/title.html" $.entry }}{{ end -}}

--- a/layouts/partials/bib/getfullname.html
+++ b/layouts/partials/bib/getfullname.html
@@ -1,0 +1,11 @@
+{{- $name := .first -}}
+{{- with .middle -}}
+  {{- range split . " " -}}
+    {{- $name = print $name " " . (cond (eq (countrunes .) 1) "." "")  -}}
+  {{- end -}}
+{{- end -}}
+{{- $name = print $name " " .last -}}
+{{- with .lineage -}}
+  {{- $name = print $name " " . -}}
+{{- end -}}
+{{- return $name -}}

--- a/layouts/partials/bib/getpeoplepages.html
+++ b/layouts/partials/bib/getpeoplepages.html
@@ -1,0 +1,6 @@
+{{- $pagesbyname := dict -}}
+{{- range where .Site.RegularPages "Section" "people" -}}
+  {{- $name := trim (replaceRE "\\p{Zs}+" " " .Params.name) " " -}}
+  {{- $pagesbyname = merge $pagesbyname (dict $name .) -}}
+{{- end -}}
+{{- return $pagesbyname -}}

--- a/layouts/partials/bib/list.html
+++ b/layouts/partials/bib/list.html
@@ -8,7 +8,7 @@
       {{- range $entry := where $bib.references "id" "==" $id }}
         {{- if not ($.Page.Scratch.Get "bibitemfound") }}
           {{- $.Page.Scratch.Set "bibitemfound" true }}
-          {{ partial "bib/entry.html" (dict "entry" $entry "params" $.Site.Params.bibliography "mark" (cond $starred "starred" "") "Page" $.Page) }}
+          {{ partial "bib/entry.html" (dict "entry" $entry "params" $.Site.Params.bibliography "mark" (cond $starred "starred" "") "peoplepages" $.peoplepages "Page" $.Page) }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/layouts/partials/bib/names.html
+++ b/layouts/partials/bib/names.html
@@ -1,8 +1,12 @@
 {{- $citemode := eq .mode "citation" -}}
 {{- $len := len .names -}}
 {{- $lastidx := sub $len 1 -}}
+{{- $hasetal := gt $len .params.etalcutoff -}}
+{{- $etallabel := "et&nbsp;al." | safeHTML -}}
+
 {{- range $idx, $author := .names -}}
-  {{- if or (le $len $.params.etalcutoff) (lt $idx $.params.etalkeep) -}}
+  {{- $insideetal := and $hasetal (ge $idx $.params.etalkeep) -}}
+  {{- if or (not $insideetal) (and $insideetal (not $citemode)) -}}
     {{- if gt $idx 0 -}}
       {{- if eq $idx $lastidx -}}
         {{- if gt $lastidx 1 -}}{{ "," }}{{ end -}}{{ " and" -}}
@@ -10,6 +14,11 @@
         {{- "," -}}
       {{- end -}}
       {{- " " -}}
+    {{- end -}}
+    {{- if and (not $citemode) $hasetal (eq $idx $.params.etalkeep) -}}
+      <span class="etal">{{ "" -}}
+        <a role="button" onclick="bib.displayEtAlNames(this)">{{ $etallabel }}</a>{{ "" -}}
+        <span class="container">{{ " " -}}
     {{- end -}}
 
     {{- $fullname := partial "bib/getfullname.html" $author -}}
@@ -61,4 +70,12 @@
     </span>
   {{- end -}}
 {{- end -}}
-{{- if gt $len .params.etalcutoff }}{{ ", et al." }}{{ end -}}
+
+{{- if $hasetal -}}
+  {{- if $citemode -}}
+    {{- ", " }}<span class="etal name">{{ $etallabel }}</span>
+  {{- else -}}
+      </span>{{- /* class="container" */ -}}
+    </span>{{- /* class="etal" */ -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/bib/names.html
+++ b/layouts/partials/bib/names.html
@@ -12,51 +12,53 @@
       {{- " " -}}
     {{- end -}}
 
-    {{- $authorurl := "" -}}
-    {{- if not $citemode -}}
-      {{- $isourown := true -}}
-      {{- $fullname := partial "bib/getfullname.html" $author -}}
-      {{- with index $.peoplepages $fullname -}}
-        {{- $authorurl = .Permalink -}}
-      {{- else -}}
-        {{- with $.params.collaborators -}}
-          {{- with where . "name" $fullname -}}
-            {{- $authorurl = (index . 0).url -}}
-            {{- $isourown = false -}}
+    {{- $fullname := partial "bib/getfullname.html" $author -}}
+    <span class="name"{{ if and (not $citemode) (not $.params.fullnames) }} title="{{ $fullname }}"{{ end }}>
+      {{- $authorurl := "" -}}
+      {{- if not $citemode -}}
+        {{- $isourown := true -}}
+        {{- with index $.peoplepages $fullname -}}
+          {{- $authorurl = .Permalink -}}
+        {{- else -}}
+          {{- with $.params.collaborators -}}
+            {{- with where . "name" $fullname -}}
+              {{- $authorurl = (index . 0).url -}}
+              {{- $isourown = false -}}
+            {{- end -}}
           {{- end -}}
         {{- end -}}
+        {{- with $authorurl -}}
+          <a href="{{ . }}" class="subtle"{{ if not $isourown}} target="_blank"{{ end }}>
+        {{- end -}}
       {{- end -}}
-      {{- with $authorurl -}}
-        <a href="{{ . }}" class="subtle"{{ if not $isourown}} target="_blank"{{ end }}>
-      {{- end -}}
-    {{- end -}}
 
-    {{- if and (index $author "first") (or (not $citemode) $.params.citefirstnames) -}}
-      {{- if $.params.fullnames -}}
-        {{- $author.first -}}
-        {{- with $author.middle -}}
-          {{- range split . " " -}}
-            &nbsp;{{ . }}{{ if eq (countrunes .) 1 }}{{ "." }}{{ end -}}
+      {{- if and (index $author "first") (or (not $citemode) $.params.citefirstnames) -}}
+        {{- if $.params.fullnames -}}
+          {{- $author.first -}}
+          {{- with $author.middle -}}
+            {{- range split . " " -}}
+              &nbsp;{{ . }}{{ if eq (countrunes .) 1 }}{{ "." }}{{ end -}}
+            {{- end -}}
           {{- end -}}
-        {{- end -}}
-        {{- " " -}}
-      {{- else -}}
-        {{- range $i, $name := split $author.first "-" -}}
-          {{- if gt $i 0 }}{{ "-" }}{{ end -}}
-          {{- substr $name 0 1 }}{{ "." -}}
-        {{- end -}}
-        {{- with $author.middle -}}
-          {{- range split . " " -}}
-            &nbsp;{{ substr . 0 1 }}{{ "." -}}
+          {{- " " -}}
+        {{- else -}}
+          {{- range $i, $name := split $author.first "-" -}}
+            {{- if gt $i 0 }}{{ "-" }}{{ end -}}
+            {{- substr $name 0 1 }}{{ "." -}}
           {{- end -}}
+          {{- with $author.middle -}}
+            {{- range split . " " -}}
+              &nbsp;{{ substr . 0 1 }}{{ "." -}}
+            {{- end -}}
+          {{- end -}}
+          &nbsp;
         {{- end -}}
-        &nbsp;
       {{- end -}}
-    {{- end -}}
-    {{- $author.last -}}
-    {{- with $author.lineage }}{{ ", " }}{{ . }}{{ end -}}
+      {{- $author.last -}}
+      {{- with $author.lineage }}{{ ", " }}{{ . }}{{ end -}}
 
-    {{- if $authorurl }}</a>{{ end -}}
+      {{- if $authorurl }}</a>{{ end -}}
+    </span>
   {{- end -}}
 {{- end -}}
 {{- if gt $len .params.etalcutoff }}{{ ", et al." }}{{ end -}}

--- a/layouts/partials/bib/names.html
+++ b/layouts/partials/bib/names.html
@@ -11,6 +11,15 @@
       {{- end -}}
       {{- " " -}}
     {{- end -}}
+
+    {{- $hasauthorlink := false -}}
+    {{- if and (not $citemode) $.peoplepages -}}
+      {{- with partial "bib/getfullname.html" $author | index $.peoplepages -}}
+        {{- $hasauthorlink = true -}}
+        <a href="{{ .Permalink }}" class="subtle">
+      {{- end -}}
+    {{- end -}}
+
     {{- if and (index $author "first") (or (not $citemode) $.params.citefirstnames) -}}
       {{- if $.params.fullnames -}}
         {{- $author.first -}}
@@ -35,6 +44,8 @@
     {{- end -}}
     {{- $author.last -}}
     {{- with $author.lineage }}{{ ", " }}{{ . }}{{ end -}}
+
+    {{- if $hasauthorlink }}</a>{{ end -}}
   {{- end -}}
 {{- end -}}
 {{- if gt $len .params.etalcutoff }}{{ ", et al." }}{{ end -}}

--- a/layouts/partials/bib/names.html
+++ b/layouts/partials/bib/names.html
@@ -12,11 +12,22 @@
       {{- " " -}}
     {{- end -}}
 
-    {{- $hasauthorlink := false -}}
-    {{- if and (not $citemode) $.peoplepages -}}
-      {{- with partial "bib/getfullname.html" $author | index $.peoplepages -}}
-        {{- $hasauthorlink = true -}}
-        <a href="{{ .Permalink }}" class="subtle">
+    {{- $authorurl := "" -}}
+    {{- if not $citemode -}}
+      {{- $isourown := true -}}
+      {{- $fullname := partial "bib/getfullname.html" $author -}}
+      {{- with index $.peoplepages $fullname -}}
+        {{- $authorurl = .Permalink -}}
+      {{- else -}}
+        {{- with $.params.collaborators -}}
+          {{- with where . "name" $fullname -}}
+            {{- $authorurl = (index . 0).url -}}
+            {{- $isourown = false -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+      {{- with $authorurl -}}
+        <a href="{{ . }}" class="subtle"{{ if not $isourown}} target="_blank"{{ end }}>
       {{- end -}}
     {{- end -}}
 
@@ -45,7 +56,7 @@
     {{- $author.last -}}
     {{- with $author.lineage }}{{ ", " }}{{ . }}{{ end -}}
 
-    {{- if $hasauthorlink }}</a>{{ end -}}
+    {{- if $authorurl }}</a>{{ end -}}
   {{- end -}}
 {{- end -}}
 {{- if gt $len .params.etalcutoff }}{{ ", et al." }}{{ end -}}

--- a/layouts/partials/bib/section.html
+++ b/layouts/partials/bib/section.html
@@ -1,3 +1,4 @@
+{{- $peoplepages := partial "bib/getpeoplepages.html" . -}}
 <section class="bibliography">
   {{ with .title }}<h1>{{ . }}</h1>{{ end }}
   {{- range $group := .items }}
@@ -6,7 +7,7 @@
       {{ with $group.foreword -}}
         <div class="foreword">{{ markdownify . }}</div>
       {{- end }}
-      {{ partial "bib/list.html" (dict "items" $group.items "Page" $.Page "Site" $.Site) }}
+      {{ partial "bib/list.html" (dict "items" $group.items "peoplepages" $peoplepages "Page" $.Page "Site" $.Site) }}
     </div>
   {{- end }}
 </section>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -336,6 +336,10 @@ a.citation .title::after {
   margin-left: 0.4pt;
 }
 
+.bibliography>li .bibentry .etal>.container {
+  display: none;
+}
+
 .bibliography>li .bibentry .extras {
   font-size: calc(0.7 * var(--font-size));
 }

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -1,5 +1,15 @@
 "use strict";
+
 var bib = {
+	displayEtAlNames: function(button) {
+		var etalElem = button.parentNode;
+		if (!etalElem || !etalElem.classList.contains("etal")) return;
+		var etalContainer = etalElem.querySelector(".container");
+		if (!etalContainer) return;
+		etalContainer.style.display = "inline";
+		button.style.display = "none";
+	},
+
 	toggleBibtexDisplay: function(button) {
 		var entry = button;
 		while (entry && (!entry.classList.contains("bibentry") || !entry.id))
@@ -16,5 +26,5 @@ var bib = {
 			button.textContent = button.textContent.replace(/^▾/, "▸");
 			bibtex.style.display = "none";
 		}
-	}
+	},
 }


### PR DESCRIPTION
When generating bibliographies, match the full names of authors and
editors with the full names of lab members as indicated by the `name`
field of the personal pages’ metadata. Differences in whitespace are
ignored when matching names.

If the name is not found among lab members, look for it in the list
of known collaborators defined by the `collaborators` array in the
global bibliography parameters under the website configuration.
A collaborator is defined by their full name and a url to their website.

For all links to be found and generated perfectly, it is required that
(1) the name field in the metadata of a personal page lists the full
name of the person that they also use in the BibTeX entries for their
publications;
(2) there is no two people with the same full name in the lab;
(3) there is no external collaborators in the BibTeX entries that bear
the same full name as a person in the lab.

However, nothing breaks if any of these three assumptions is violated:
some author or editor links might be missing (if (1) or (2) does not hold),
or might be leading to the wrong person (if (2) or (3) does not hold).
Given that such name clashes will almost surely never happen,
the benefits of having author links in general outweighs the unlikely
downside of one of them being missing or leading to a different person
with the same name, anyway, in my opinion. (Especially since we can
take some measures to disambiguate names in case of a clash.)

Additionally, create tooltips with full names for all authors or
editors in bibliographies, if the website is configured to shorten
first and middle names to initials when generating bibliographies
(i.e., the `bibliography.fullnames` parameter is set to `false`).