### PR TITLE
Add controls for interactively filtering bibliographies by text and entry type

### DIFF
--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -1,6 +1,17 @@
 {{- $entrykindattr := .entry.kind | htmlEscape -}}
 <li class="{{ $entrykindattr }}{{ with .mark }} {{ . }}{{ end }}" data-bib-kind="{{ $entrykindattr }}">{{ "" -}}
 <section id="{{ .entry.id | urlize }}" class="bibentry {{ $entrykindattr }}">
+
+{{- range $namesfield := (slice "author" "editor") -}}
+  <span class="{{ $namesfield }}s-index">
+    {{- range $person := index $.entry $namesfield | default slice -}}
+      {{- range slice "first" "middle" "last" "lineage" -}}
+        {{- . | index $person | default "" }}{{ " " -}}
+      {{- end -}}
+    {{- end -}}
+  </span>
+{{- end -}}
+
 {{- if false -}}
 
 {{- else if eq .entry.kind "book" -}}

--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -11,6 +11,7 @@
     {{- end -}}
   </span>
 {{- end -}}
+<span class="keywords-index">{{ .entry.keyword }}</span>
 
 {{- if false -}}
 

--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -1,5 +1,6 @@
-<li class="{{ .entry.kind | htmlEscape }}{{ with .mark }} {{ . }}{{ end }}">{{ "" -}}
-<section id="{{ .entry.id | urlize }}" class="bibentry {{ .entry.kind | htmlEscape }}">
+{{- $entrykindattr := .entry.kind | htmlEscape -}}
+<li class="{{ $entrykindattr }}{{ with .mark }} {{ . }}{{ end }}" data-bib-kind="{{ $entrykindattr }}">{{ "" -}}
+<section id="{{ .entry.id | urlize }}" class="bibentry {{ $entrykindattr }}">
 {{- if false -}}
 
 {{- else if eq .entry.kind "book" -}}

--- a/layouts/partials/bib/section.html
+++ b/layouts/partials/bib/section.html
@@ -2,7 +2,7 @@
   <header>
     {{ with .title }}<h1>{{ . }}</h1>{{ else }}<div></div>{{ end }}
     <div class="controls-anchor">
-      <div class="controls {{ if .shiftcontrolsup }}heading-margin-shift{{ end }}">
+      <div class="controls{{ if .shiftcontrolsup }} heading-margin-shift{{ end }}">
         <input id="ctl-bib-filter-input" class="filter" type="search" placeholder="Filter…" />
         <select id="ctl-bib-filter-selection" class="inactive">
           <option value="all" selected>everything</option>

--- a/layouts/partials/bib/section.html
+++ b/layouts/partials/bib/section.html
@@ -1,5 +1,12 @@
 <section class="bibliography">
-  {{ with .title }}<h1>{{ . }}</h1>{{ end }}
+  <header>
+    {{ with .title }}<h1>{{ . }}</h1>{{ else }}<div></div>{{ end }}
+    <div class="controls-anchor">
+      <div class="controls {{ if .shiftcontrolsup }}heading-margin-shift{{ end }}">
+        <input class="filter" type="search" placeholder="Filter…" />
+      </div>
+    </div>
+  </header>
   {{- range $group := .items }}
     <div class="group">
       {{ with $group.title }}<h2>{{ . }}</h2>{{ end }}

--- a/layouts/partials/bib/section.html
+++ b/layouts/partials/bib/section.html
@@ -4,6 +4,13 @@
     <div class="controls-anchor">
       <div class="controls {{ if .shiftcontrolsup }}heading-margin-shift{{ end }}">
         <input class="filter" type="search" placeholder="Filter…" />
+        <select class="selection">
+          <option value="all" selected>everything</option>
+          <option value="conferences">conferences</option>
+          <option value="journals">journals</option>
+          <option value="books">books</option>
+          <option value="other">other</option>
+        </select>
       </div>
     </div>
   </header>

--- a/layouts/partials/bib/section.html
+++ b/layouts/partials/bib/section.html
@@ -14,6 +14,9 @@
       </div>
     </div>
   </header>
+  <div id="ctl-bib-group-no-match" class="group">
+    <h2>No matches</h2>
+  </div>
   {{- range $group := .items }}
     <div class="group">
       {{ with $group.title }}<h2>{{ . }}</h2>{{ end }}

--- a/layouts/partials/bib/section.html
+++ b/layouts/partials/bib/section.html
@@ -3,8 +3,8 @@
     {{ with .title }}<h1>{{ . }}</h1>{{ else }}<div></div>{{ end }}
     <div class="controls-anchor">
       <div class="controls {{ if .shiftcontrolsup }}heading-margin-shift{{ end }}">
-        <input class="filter" type="search" placeholder="Filter…" />
-        <select class="selection">
+        <input id="ctl-bib-filter-input" class="filter" type="search" placeholder="Filter…" />
+        <select id="ctl-bib-filter-selection" class="inactive">
           <option value="all" selected>everything</option>
           <option value="conferences">conferences</option>
           <option value="journals">journals</option>

--- a/layouts/section/publications.html
+++ b/layouts/section/publications.html
@@ -5,7 +5,7 @@
       <h1 class="page-title">Publications</h1>
     </header>
     <section class="content">
-      {{ partial "bib/section.html" (dict "items" .Params.bibliography "Page" .Page "Site" .Site) }}
+      {{ partial "bib/section.html" (dict "shiftcontrolsup" true "items" .Params.bibliography "Page" .Page "Site" .Site) }}
       {{ .Content }}
     </section>
   </article>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -321,6 +321,7 @@ ul.bibliography>li.starred::before {
 
 .bibliography>li .bibentry .authors-index { display: none; }
 .bibliography>li .bibentry .editors-index { display: none; }
+.bibliography>li .bibentry .keywords-index { display: none; }
 
 .bibliography>li .bibentry .title {}
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -277,6 +277,7 @@ section.bibliography>header {
   justify-content: space-between;
 }
 section.bibliography>header>.controls-anchor {
+  width: 310px;
   position: relative;
 }
 section.bibliography>header>.controls-anchor>.controls {
@@ -287,9 +288,12 @@ section.bibliography>header>.controls-anchor>.controls {
 section.bibliography>header .controls.heading-margin-shift {
   padding-bottom: var(--heading-top-margin);
 }
-section.bibliography>header .controls input.filter {
+section.bibliography>header .controls input,
+section.bibliography>header .controls select {
   font-size: var(--font-size);
-  width: 200px;
+}
+section.bibliography>header .controls input.filter {
+  width: 170px;
 }
 
 ul.bibliography {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -40,6 +40,8 @@
   --footer-font-size: 14px;
   --line-height: 23px;
 
+  --heading-top-margin: 2ex;
+
   --body-wrap-width: 720px;
   --body-wrap-padding: 10px;
 
@@ -270,6 +272,26 @@ section.profile .contacts .address>.value {
   padding-left: 6px;
 }
 
+section.bibliography>header {
+  display: flex;
+  justify-content: space-between;
+}
+section.bibliography>header>.controls-anchor {
+  position: relative;
+}
+section.bibliography>header>.controls-anchor>.controls {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+section.bibliography>header .controls.heading-margin-shift {
+  padding-bottom: var(--heading-top-margin);
+}
+section.bibliography>header .controls input.filter {
+  font-size: var(--font-size);
+  width: 200px;
+}
+
 ul.bibliography {
   list-style: none;
   padding-left: 0;
@@ -427,7 +449,7 @@ figure>a {
 
 h1, h2, h3, h4, h5, h6 {
   color: var(--headings-fg-color);
-  margin: 2ex 0 0 0;
+  margin: var(--heading-top-margin) 0 0 0;
 }
 h1 { font-size: 140%; }
 h2 { font-size: 120%; }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2,7 +2,14 @@
   --bg-color: #fbfbfb;
   --fg-color: black;
   --lighter-fg-color: #2e2e2e;
+  --lighter-bg-color: white;
   --highlighted-bg-color: #dee6ee;
+
+  --controls-fg-color: #aaaaaa;
+  --controls-border-color: #e0e0e0;
+  --controls-active-fg-color: var(--fg-color);
+  --controls-active-bg-color: var(--lighter-bg-color);
+  --controls-active-border-color: var(--fg-color);
 
   --headings-fg-color: black;
   --headings-meta-fg-color: #787878;
@@ -40,7 +47,13 @@
   --footer-font-size: 14px;
   --line-height: 23px;
 
-  --heading-top-margin: 2ex;
+  --heading-top-margin: 18px;
+
+  --controls-font-size: 0.9em;
+  --controls-height: 1.8em;
+  --controls-underline-size: 2px;
+  --controls-active-underline-size: 1px;
+  --controls-vertical-padding: 1px;
 
   --body-wrap-width: 720px;
   --body-wrap-padding: 10px;
@@ -277,7 +290,7 @@ section.bibliography>header {
   justify-content: space-between;
 }
 section.bibliography>header>.controls-anchor {
-  width: 310px;
+  width: 300px;
   position: relative;
 }
 section.bibliography>header>.controls-anchor>.controls {
@@ -286,18 +299,58 @@ section.bibliography>header>.controls-anchor>.controls {
   right: 0;
 }
 section.bibliography>header .controls.heading-margin-shift {
-  padding-bottom: var(--heading-top-margin);
+  padding-bottom: calc(var(--heading-top-margin) - var(--controls-underline-size) - var(--controls-vertical-padding));
+}
+
+section.bibliography>header .controls .inactive {
+  color: var(--controls-fg-color);
 }
 section.bibliography>header .controls input,
 section.bibliography>header .controls select {
-  font-size: var(--font-size);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  font: inherit;
+  font-size: var(--controls-font-size);
+  height: var(--controls-height);
+  outline: none;
+  border: none;
+  border-radius: 0;
+  border-bottom: var(--controls-underline-size) solid var(--controls-border-color);
+  padding: var(--controls-vertical-padding) 0.5ex;
+  margin: 0;
+  color: var(--controls-active-fg-color);
+  background-color: transparent;
+}
+section.bibliography>header .controls input::-webkit-search-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+section.bibliography>header .controls input::placeholder {
+  color: var(--controls-fg-color);
+  opacity: 1;
+}
+section.bibliography>header .controls input:hover,
+section.bibliography>header .controls input:focus,
+section.bibliography>header .controls select:hover,
+section.bibliography>header .controls select:focus {
+  background-color: var(--controls-active-bg-color);
+  border-bottom: var(--controls-active-underline-size) solid var(--controls-active-border-color);
+  height: calc(var(--controls-height) - var(--controls-active-underline-size));
+  margin-bottom: var(--controls-active-underline-size);
+}
+section.bibliography>header .controls select:focus {
+  border-bottom-style: dotted;
 }
 section.bibliography>header .controls input.filter {
-  width: 170px;
+  width: 180px;
+  padding-right: 0;
 }
 section.bibliography>#ctl-bib-group-no-match {
   display: none;
   margin-bottom: var(--heading-top-margin);
+}
+section.bibliography>#ctl-bib-group-no-match h2 {
+  color: var(--controls-fg-color);
 }
 
 ul.bibliography {
@@ -471,7 +524,7 @@ h5 { font-size: 100%; }
 h6 { font-size: 100%; }
 h1.page-title {
   font-size: 180%;
-  margin: 1.4ex 0 1ex 0;
+  margin: calc(1.2 * var(--heading-top-margin)) 0 var(--heading-top-margin) 0;
 }
 header>h2.meta, header>h3.meta, header>h4.meta,
 header>h5.meta, header>h6.meta {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -295,6 +295,10 @@ section.bibliography>header .controls select {
 section.bibliography>header .controls input.filter {
   width: 170px;
 }
+section.bibliography>#ctl-bib-group-no-match {
+  display: none;
+  margin-bottom: var(--heading-top-margin);
+}
 
 ul.bibliography {
   list-style: none;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -63,6 +63,9 @@
   --profile-portrait-margin-left: 20px;
   --profile-portrait-margin-bottom: 30px;
   --project-cover-image-size: 320px;
+
+  --icon-search-inactive: url('data:image/svg+xml,<svg width="40" height="40pt" viewBox="0 0 30 40" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><g id="b"><defs><path id="a" d="M13 12a7 7 0 110 14 7 7 0 010-14z"/></defs><use xlink:href="%23a" fill="none" stroke="%23cecece" stroke-miterlimit="10" stroke-width="2"/></g></defs><use xlink:href="%23b"/><defs><g id="d"><defs><path id="c" d="M18.478 24.478L24 30"/></defs><use xlink:href="%23c" fill="none" stroke="%23cecece" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"/></g></defs><use xlink:href="%23d"/></svg>');
+  --icon-dropdown-inactive: url('data:image/svg+xml,<svg width="25pt" height="40pt" viewBox="0 0 25 40" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><g id="b"><defs><path id="a" d="M8 18.5l4.5-4.5 4.5 4.5"/></defs><use xlink:href="%23a" fill="none" stroke="%23cecece" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2.5"/></g></defs><use xlink:href="%23b"/><defs><g id="d"><defs><path id="c" d="M17 25.5L12.5 30 8 25.5"/></defs><use xlink:href="%23c" fill="none" stroke="%23cecece" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2.5"/></g></defs><use xlink:href="%23d"/></svg>');
 }
 
 body {
@@ -343,7 +346,18 @@ section.bibliography>header .controls select:focus {
 }
 section.bibliography>header .controls input.filter {
   width: 180px;
+  padding-left: 2.8ex;
   padding-right: 0;
+  background: var(--icon-search-inactive) left/contain no-repeat scroll;
+  background-color: transparent;
+}
+section.bibliography>header .controls input.filter:hover,
+section.bibliography>header .controls input.filter:focus {
+  background-color: var(--controls-active-bg-color);
+}
+section.bibliography>header .controls select {
+  background: var(--icon-dropdown-inactive) right/contain no-repeat scroll;
+  padding-right: 2.25ex;
 }
 section.bibliography>#ctl-bib-group-no-match {
   display: none;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -319,6 +319,9 @@ ul.bibliography>li.starred::before {
 }
 .bibliography>li .bibentry:target { background-color: var(--highlighted-bg-color); }
 
+.bibliography>li .bibentry .authors-index { display: none; }
+.bibliography>li .bibentry .editors-index { display: none; }
+
 .bibliography>li .bibentry .title {}
 
 .bibliography>li .bibentry.book .title,

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -1,5 +1,74 @@
 "use strict";
+
 var bib = {
+	sectionSelector: "section.bibliography",
+	sectionGroupsSelector: ".group",
+	groupEntriesSelector: "ul.bibliography>li",
+	entryFieldsSelector: [
+		".authors", ".editors",
+		".title", ".journal", ".booktitle", ".series",
+		".organization", ".institution", ".school",
+		".publisher", ".address", ".date",
+		".note",
+	].join(","),
+	filterInputSelector: "input.filter",
+
+	initEntryTextFilter: function() {
+		var sectionElem = document.querySelector(bib.sectionSelector);
+		var groupElems = sectionElem.querySelectorAll(bib.sectionGroupsSelector);
+		var groups = [];
+		for (var groupElem of groupElems) {
+			var entryElems = groupElem.querySelectorAll(bib.groupEntriesSelector);
+			var entries = [];
+			for (var entryElem of entryElems) {
+				var fieldElems = entryElem.querySelectorAll(bib.entryFieldsSelector);
+				var values = [];
+				for (var fieldElem of fieldElems)
+					values.push(fieldElem.innerText.toLowerCase());
+				entries.push({
+					element: entryElem,
+					values: values,
+				});
+			}
+			groups.push({
+				element: groupElem,
+				entries: entries,
+			});
+		}
+		bib.entryGroups = groups;
+
+		bib.filterInputElem = sectionElem.querySelector(bib.filterInputSelector)
+		bib.filterInputElem.oninput = bib.filterEntries
+	},
+
+	doStringsMatch: function(strings, queryWords) {
+		for (var qw of queryWords) {
+			var found = false;
+			for (var str of strings) {
+				if (str.indexOf(qw) != -1) {
+					found = true;
+					break;
+				}
+			}
+			if (!found)
+				return false;
+		}
+		return true;
+	},
+
+	filterEntries: function() {
+		var queryWords = bib.filterInputElem.value.toLowerCase().split(/\s+/);
+		for (var group of bib.entryGroups) {
+			var numVisible = group.entries.length
+			for (var item of group.entries) {
+				var matched = bib.doStringsMatch(item.values, queryWords);
+				item.element.style.display = (matched ? "list-item" : "none");
+				numVisible -= !matched;
+			}
+			group.element.style.display = (numVisible > 0 ? "block" : "none");
+		}
+	},
+
 	toggleBibtexDisplay: function(button) {
 		var entry = button;
 		while (entry && (!entry.classList.contains("bibentry") || !entry.id))
@@ -16,5 +85,7 @@ var bib = {
 			button.textContent = button.textContent.replace(/^▾/, "▸");
 			bibtex.style.display = "none";
 		}
-	}
+	},
 }
+
+window.onload = bib.initEntryTextFilter;

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -5,7 +5,7 @@ var bib = {
 	sectionGroupsSelector: ".group",
 	groupEntriesSelector: "ul.bibliography>li",
 	entryFieldsSelector: [
-		".authors", ".editors",
+		".authors-index", ".editors-index",
 		".title", ".journal", ".booktitle", ".series",
 		".organization", ".institution", ".school",
 		".publisher", ".address", ".date",

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -111,15 +111,7 @@ var bib = {
 			totalVisible += groupVisible;
 		}
 		bib.noMatchGroup.style.display = (totalVisible > 0 ? "none" : "block");
-	displayEtAlNames: function(button) {
-		var etalElem = button.parentNode;
-		if (!etalElem || !etalElem.classList.contains("etal")) return;
-		var etalContainer = etalElem.querySelector(".container");
-		if (!etalContainer) return;
-		etalContainer.style.display = "inline";
-		button.style.display = "none";
 	},
-
 	toggleBibtexDisplay: function(button) {
 		var entry = button;
 		while (entry && (!entry.classList.contains(bib.entryContentClass) || !entry.id))
@@ -143,6 +135,14 @@ var bib = {
 			);
 			bibtex.style.display = "none";
 		}
+	},
+	displayEtAlNames: function(button) {
+		var etalElem = button.parentNode;
+		if (!etalElem || !etalElem.classList.contains("etal")) return;
+		var etalContainer = etalElem.querySelector(".container");
+		if (!etalContainer) return;
+		etalContainer.style.display = "inline";
+		button.style.display = "none";
 	},
 }
 

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -14,6 +14,7 @@ var bib = {
 	].join(","),
 	sectionFilterInputSelector: "#ctl-bib-filter-input",
 	sectionFilterSelectSelector: "#ctl-bib-filter-selection",
+	filterSelectInactiveClass: "inactive",
 
 	entryKindAttrName: "data-bib-kind",
 	entryKindSelectionMap: {
@@ -93,6 +94,11 @@ var bib = {
 			words: bib.filterInputElem.value.toLowerCase().split(/\s+/),
 			selection: bib.filterSelectElem.value,
 		};
+		if (query.selection == bib.entrySelectionTagAll) {
+			bib.filterSelectElem.classList.add(bib.filterSelectInactiveClass);
+		} else {
+			bib.filterSelectElem.classList.remove(bib.filterSelectInactiveClass);
+		}
 		var totalVisible = 0;
 		for (var group of bib.entryGroups) {
 			var groupVisible = 0;

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -3,6 +3,7 @@
 var bib = {
 	sectionSelector: "section.bibliography",
 	sectionGroupsSelector: ".group",
+	sectionNoMatchGroupSelector: "#ctl-bib-group-no-match",
 	groupEntriesSelector: "ul.bibliography>li",
 	entryFieldsSelector: [
 		".authors-index", ".editors-index",
@@ -56,6 +57,7 @@ var bib = {
 			});
 		}
 		bib.entryGroups = groups;
+		bib.noMatchGroup = sectionElem.querySelector(bib.sectionNoMatchGroupSelector);
 
 		bib.filterInputElem = sectionElem.querySelector(bib.sectionFilterInputSelector);
 		bib.filterSelectElem = sectionElem.querySelector(bib.sectionFilterSelectSelector);
@@ -91,15 +93,18 @@ var bib = {
 			words: bib.filterInputElem.value.toLowerCase().split(/\s+/),
 			selection: bib.filterSelectElem.value,
 		};
+		var totalVisible = 0;
 		for (var group of bib.entryGroups) {
-			var numVisible = group.entries.length;
+			var groupVisible = 0;
 			for (var entry of group.entries) {
 				var matched = bib.entryMatchesQuery(entry, query);
 				entry.element.style.display = (matched ? "list-item" : "none");
-				numVisible -= !matched;
+				groupVisible += matched;
 			}
-			group.element.style.display = (numVisible > 0 ? "block" : "none");
+			group.element.style.display = (groupVisible > 0 ? "block" : "none");
+			totalVisible += groupVisible;
 		}
+		bib.noMatchGroup.style.display = (totalVisible > 0 ? "none" : "block");
 	},
 
 	toggleBibtexDisplay: function(button) {

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -9,7 +9,7 @@ var bib = {
 		".title", ".journal", ".booktitle", ".series",
 		".organization", ".institution", ".school",
 		".publisher", ".address", ".date",
-		".note",
+		".note", ".keywords-index",
 	].join(","),
 	sectionFilterInputSelector: "input.filter",
 	sectionFilterSelectSelector: "select.selection",

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -27,6 +27,11 @@ var bib = {
 	entrySelectionTagAll: "all",
 	entrySelectionTagOther: "other",
 
+	entryContentClass: "bibentry",
+	entryBibtexClass: "bibtex",
+	entryBibtexCollapsedSign: "▸",
+	entryBibtexExpandedSign: "▾",
+
 	initEntryTextFilter: function() {
 		var sectionElem = document.querySelector(bib.sectionSelector);
 		var groupElems = sectionElem.querySelectorAll(bib.sectionGroupsSelector);
@@ -99,18 +104,25 @@ var bib = {
 
 	toggleBibtexDisplay: function(button) {
 		var entry = button;
-		while (entry && (!entry.classList.contains("bibentry") || !entry.id))
+		while (entry && (!entry.classList.contains(bib.entryContentClass) || !entry.id))
 			entry = entry.parentNode;
 		if (!entry) return;
 
-		var query = entry.tagName + ".bibentry#" + entry.id + ">.bibtex";
-		var bibtex = document.querySelector(query);
+		var selector = entry.tagName + "." + bib.entryContentClass +
+			"#" + entry.id + ">." + bib.entryBibtexClass;
+		var bibtex = document.querySelector(selector);
 		if (!bibtex) return;
 		if (!bibtex.style.display || bibtex.style.display == "none") {
-			button.textContent = button.textContent.replace(/^▸/, "▾");
+			button.textContent = button.textContent.replace(
+				bib.entryBibtexCollapsedSign,
+				bib.entryBibtexExpandedSign
+			);
 			bibtex.style.display = "block";
 		} else {
-			button.textContent = button.textContent.replace(/^▾/, "▸");
+			button.textContent = button.textContent.replace(
+				bib.entryBibtexExpandedSign,
+				bib.entryBibtexCollapsedSign
+			);
 			bibtex.style.display = "none";
 		}
 	},

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -12,8 +12,8 @@ var bib = {
 		".publisher", ".address", ".date",
 		".note", ".keywords-index",
 	].join(","),
-	sectionFilterInputSelector: "input.filter",
-	sectionFilterSelectSelector: "select.selection",
+	sectionFilterInputSelector: "#ctl-bib-filter-input",
+	sectionFilterSelectSelector: "#ctl-bib-filter-selection",
 
 	entryKindAttrName: "data-bib-kind",
 	entryKindSelectionMap: {


### PR DESCRIPTION
Add a client-side JavaScript-powered interface for live filtering
of entries in the bibliography section on every page having one.

Consists of two instruments: a simple text occurrence search
and an entry type selection. Filtering queries are split into
whitespace-separated words, each of which must be found in
case-insensitive manner as a substring somewhere within an entry
for it to be kept visible. Additionally, all publications are grouped
into four general categories: ‘conferences’, ‘journals’, ‘books’, and
‘other’, based on their exact BibTeX entry type, which can be used
as an additional filtering factor.

The fields that are matched against the query words are:
- the lists of full author and editor names (invisible on the page
and added for the purposes of filtering only in addition to the
visible author and editor lists, which might be trimmed or
have first and middle names shortened to initials);
- the titles of the paper itself, journal, book or proceedings,
and book series;
- the names of organization, institution, or school;
- the name and address of the publisher;
- the publication date (as it is rendered on the page),
- the note text with extra information (usually on the status
of the submission);
- the keywords list (also invisible on the page).

See the descriptions of the commits in this branch for technical details.

It might be interesting to implement a potentially more performant
text automaton via directed acyclic word graph (DAWG) automata,
but even this simple implementation is performant enough for our
demands currently and in the foreseeable future (the maximum number
of bibliography entries will likely never exceed a few hundreds).

It also might be interesting to implement a fuzzy matcher (perhaps
via some existing library), but fuzzy matching does not mount well
with *filtering*. It is more suitable for *searching* instead, which involves
ranking and, therefore, requires reordering entries on the page,
making it all much more complicated and not agreeable well with
grouping bibliography entries into sections.