### PR TITLE
Properly handle the contents of the ‘abstract’ field, when present in BibTeX files

### DIFF
--- a/data/bib/iasl.yaml
+++ b/data/bib/iasl.yaml
@@ -1,26 +1,14 @@
 references:
-- abstract: 'The analysis of information rich signals is at the core of autonomy.
-    In
-
-    airborne devices such as Unmanned Aerial Vehicles (UAV), the hardware
-
-    limitations imposed by the weight constraints make the continuous execution
-
-    of these algorithms challenging. Edge computing can mitigate such
-
-    limitations and boost the system and mission performance of the UAVs.
-
-    However, due to the UAVs motion characteristics and complex dynamics of
-
-    urban environments, remote processing-control loops can quickly degrade.
-
-    This paper presents Hydra, a framework for the dynamic selection of
-
-    communication/computation resources in this challenging environment. A full
-
-    -- open-source -- implementation of Hydra is discussed and tested via
-
-    real-world experiments.'
+- abstract: The analysis of information rich signals is at the core of autonomy. In
+    airborne devices such as Unmanned Aerial Vehicles (UAV), the hardware limitations
+    imposed by the weight constraints make the continuous execution of these algorithms
+    challenging. Edge computing can mitigate such limitations and boost the system
+    and mission performance of the UAVs. However, due to the UAVs motion characteristics
+    and complex dynamics of urban environments, remote processing-control loops can
+    quickly degrade. This paper presents Hydra, a framework for the dynamic selection
+    of communication/computation resources in this challenging environment. A full
+    – open-source – implementation of Hydra is discussed and tested via real-world
+    experiments.
   address: Dublin, Ireland
   author:
   - first: Davide
@@ -34,16 +22,7 @@ references:
     \ for Infrastructure-Assisted Autonomous {UAVs}},\n  booktitle = {Proceedings\
     \ of the IEEE International Conference on Communications (ICC)},\n  note = {SAC\
     \ Tactile Internet Track; accepted, publication pending},\n  address = {Dublin,\
-    \ Ireland},\n  month = jun,\n  year = {2020},\n  abstract = {The analysis of information\
-    \ rich signals is at the core of autonomy. In\nairborne devices such as Unmanned\
-    \ Aerial Vehicles (UAV), the hardware\nlimitations imposed by the weight constraints\
-    \ make the continuous execution\nof these algorithms challenging. Edge computing\
-    \ can mitigate such\nlimitations and boost the system and mission performance\
-    \ of the UAVs.\nHowever, due to the UAVs motion characteristics and complex dynamics\
-    \ of\nurban environments, remote processing-control loops can quickly degrade.\n\
-    This paper presents Hydra, a framework for the dynamic selection of\ncommunication/computation\
-    \ resources in this challenging environment. A full\n-- open-source -- implementation\
-    \ of Hydra is discussed and tested via\nreal-world experiments.},\n}"
+    \ Ireland},\n  month = jun,\n  year = {2020},\n}"
   booktitle: Proceedings of the IEEE International Conference on Communications (ICC)
   id: callegaro-baidya-2020-icc
   kind: inproceedings

--- a/scripts/bibtex2yaml
+++ b/scripts/bibtex2yaml
@@ -11,10 +11,9 @@ import yaml
 
 from bibtexparser.bibdatabase import as_text as bib_expr_as_text
 
-# The BibTeX fields recognized by the commonly used bibliography
-# styles. The values of these fields are treated as LaTeX expressions.
-# When the BibTeX source is formatted, these fields are put in front
-# in the same order as below. (Hence the tuple instead of a set.)
+# The BibTeX fields recognized by the standard bibliography styles.
+# When a BibTeX entry is formatted, these fields are put in front in
+# the same order as below. (Hence the tuple instead of a set.)
 BIBTEX_STANDARD_TAGS = (
 	'author',
 	'title',
@@ -41,7 +40,7 @@ BIBTEX_STANDARD_TAGS = (
 )
 
 # The BibTeX fields parsed as lists of names separated by the word
-# 'and' (when it is not inside of an expression protected by braces).
+# 'and' (when occurring outside of expressions protected by braces).
 BIBTEX_NAMELIST_TAGS = {
 	'author',
 	'editor',
@@ -61,7 +60,7 @@ BIBTEX_TITLECASE_TAGS = {
 	'organization',
 	'publisher',
 }
-# A subset of the fields in BIBTEX_TITLECASE_TAGS whose values are
+# A subset of the fields from BIBTEX_TITLECASE_TAGS whose values are
 # rewritten in sentence case when converted into text (if so requested
 # at invocation). Values of all other fields in BIBTEX_TITLECASE_TAGS
 # are rewritten in title case, still.
@@ -69,17 +68,27 @@ BIBTEX_SENTENCECASE_TAGS = {
 	'title',
 }
 
-# When generating a BibTeX snippet for a separate entry, expand
-# expressions using @string{} variables in the values of all fields
-# except for the following ones.
+# The nonstandard BibTeX fields whose values are formatted in LaTeX.
+BIBTEX_EXTRA_TEX_TAGS = {
+	'abstract',
+}
+
+# The BibTeX fields whose values are not to undergo the expansion of
+# @string{} variables when generating a snippet for a separate entry.
 BIBTEX_SNIPPET_KEEP_VARS_TAGS = {
 	'month',
 }
 
+# The BibTeX fields whose values are to be treated as LaTeX code.
+BIBTEX_TEX_TAGS = set().union(
+	BIBTEX_STANDARD_TAGS,
+	BIBTEX_EXTRA_TEX_TAGS,
+)
+
 assert BIBTEX_NAMELIST_TAGS.issubset(BIBTEX_STANDARD_TAGS)
 assert BIBTEX_TITLECASE_TAGS.issubset(BIBTEX_STANDARD_TAGS)
 assert BIBTEX_SENTENCECASE_TAGS.issubset(BIBTEX_TITLECASE_TAGS)
-assert BIBTEX_SNIPPET_KEEP_VARS_TAGS.issubset(BIBTEX_STANDARD_TAGS)
+assert BIBTEX_EXTRA_TEX_TAGS.isdisjoint(BIBTEX_STANDARD_TAGS)
 
 class CaseChange(enum.Enum):
 	TITLE = 'title'
@@ -189,13 +198,12 @@ def make_record(bib_entry, include_bibtex, case_change):
 		record['bibtex'] = format_bibtex(bib_entry)
 	for tag in bib_entry:
 		value = bib_expr_as_text(bib_entry[tag])
-		if tag in BIBTEX_STANDARD_TAGS:
-			if tag in BIBTEX_NAMELIST_TAGS:
-				record[tag] = break_names(tag, value, case_change)
-			elif tag in BIBTEX_TITLECASE_TAGS:
-				record[tag] = format_title(tag, value, case_change)
-			else:
-				record[tag] = detexify(value)
+		if tag in BIBTEX_NAMELIST_TAGS:
+			record[tag] = break_names(tag, value, case_change)
+		elif tag in BIBTEX_TITLECASE_TAGS:
+			record[tag] = format_title(tag, value, case_change)
+		elif tag in BIBTEX_TEX_TAGS:
+			record[tag] = detexify(value)
 		elif tag not in ('ID', 'ENTRYTYPE'):
 			record[tag] = value
 	return record

--- a/scripts/bibtex2yaml
+++ b/scripts/bibtex2yaml
@@ -73,6 +73,12 @@ BIBTEX_EXTRA_TEX_TAGS = {
 	'abstract',
 }
 
+# The BibTeX fields to be omitted from the output when generating
+# a snippet for a separate entry.
+BIBTEX_SNIPPET_IGNORE_TAGS = {
+	'abstract',
+}
+
 # The BibTeX fields whose values are not to undergo the expansion of
 # @string{} variables when generating a snippet for a separate entry.
 BIBTEX_SNIPPET_KEEP_VARS_TAGS = {
@@ -89,6 +95,8 @@ assert BIBTEX_NAMELIST_TAGS.issubset(BIBTEX_STANDARD_TAGS)
 assert BIBTEX_TITLECASE_TAGS.issubset(BIBTEX_STANDARD_TAGS)
 assert BIBTEX_SENTENCECASE_TAGS.issubset(BIBTEX_TITLECASE_TAGS)
 assert BIBTEX_EXTRA_TEX_TAGS.isdisjoint(BIBTEX_STANDARD_TAGS)
+assert BIBTEX_SNIPPET_IGNORE_TAGS.isdisjoint(BIBTEX_STANDARD_TAGS)
+assert BIBTEX_SNIPPET_KEEP_VARS_TAGS.isdisjoint(BIBTEX_SNIPPET_IGNORE_TAGS)
 
 class CaseChange(enum.Enum):
 	TITLE = 'title'
@@ -150,6 +158,7 @@ def format_bibtex(bib_entry):
 	db.entries = [{
 		tag: val if tag in BIBTEX_SNIPPET_KEEP_VARS_TAGS else bib_expr_as_text(val)
 		for tag, val in bib_entry.items()
+		if tag not in BIBTEX_SNIPPET_IGNORE_TAGS
 	}]
 	return bibtex_writer().write(db).rstrip('\n')
 


### PR DESCRIPTION
It makes sense to keep the text of a paper’s abstract next to its
bibliography data in the BibTeX source files. The nonstandard
‘abstract’ field may be used for that purpose.

However, for the purposes of best presentation of bibliography
references in the automatically generated publication lists within
the site, additional steps are desirable during the generation of
the bibliography data.

1. Convert the LaTeX-formatted source stored in the ‘abstract’
field into a Unicode plain text ready to be used on a web page
(just like the ‘title’ or other similarly-treated standard fields).
2. Omit the ‘abstract’ field from the BibTeX snippets generated
for showing next to the reference’s entry in publications lists,
to keep those snippets lightweight.

This changeset updates the `bibtex2yaml` script to support
both of the above features generally, and uses them to improve
handling of the ‘abstract’ field. Additionally, it regenerates the
bibliography data to update it in accordance to the new treatment
of the abstracts in BibTeX sources.