### PR TITLE
Enhance publication lists to support showing abstracts, whenever available

### DIFF
--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -256,8 +256,14 @@
   </span>
 
   <div class="appendix">
-    {{- with .entry.abstract }}<div class="item abstract">{{ . }}</div>{{ end -}}
-    {{- with .entry.bibtex }}<pre class="item bibtex"><code>{{ . }}</code></pre>{{ end -}}
+    {{- with .entry.abstract -}}
+      <div class="item abstract">
+        {{- range split . "\n\n" }}<p>{{ . }}</p>{{ end -}}
+      </div>
+    {{- end -}}
+    {{- with .entry.bibtex -}}
+      <pre class="item bibtex"><code>{{ . }}</code></pre>
+    {{- end -}}
   </div>
 
 </section></li>

--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -242,6 +242,11 @@
     {{- with .entry.doi -}}
       <span class="item pubref"><a href="https://doi.org/{{ . }}">Web</a></span>
     {{- end -}}
+    {{- if index .entry "abstract" -}}
+      <span class="item abstract">{{ "" -}}
+        <a role="button" onclick="bib.toggleAbstractDisplay(this)">▸Abstract</a>{{ "" -}}
+      </span>
+    {{- end -}}
     {{- if index .entry "bibtex" -}}
       <span class="item bibtex">{{ "" -}}
         <a role="button" onclick="bib.toggleBibtexDisplay(this)">▸BibTeX</a>{{ "" -}}
@@ -250,6 +255,9 @@
     <span class="item linkhere"><a href="{{ .Page.Permalink }}#{{ .entry.id | urlize }}">¶</a></span>
   </span>
 
-  {{- with .entry.bibtex }}<pre class="bibtex"><code>{{ . }}</code></pre>{{ end -}}
+  <div class="appendix">
+    {{- with .entry.abstract }}<div class="item abstract">{{ . }}</div>{{ end -}}
+    {{- with .entry.bibtex }}<pre class="item bibtex"><code>{{ . }}</code></pre>{{ end -}}
+  </div>
 
 </section></li>

--- a/layouts/partials/bib/entry.html
+++ b/layouts/partials/bib/entry.html
@@ -262,7 +262,7 @@
       </div>
     {{- end -}}
     {{- with .entry.bibtex -}}
-      <pre class="item bibtex"><code>{{ . }}</code></pre>
+      <div class="item bibtex"><code>{{ . }}</code></div>
     {{- end -}}
   </div>
 

--- a/scripts/bibtex2yaml
+++ b/scripts/bibtex2yaml
@@ -119,7 +119,14 @@ def render_tex(tex_nodes):
 	).nodelist_to_text(tex_nodes)
 
 def detexify(str):
-	return clean_ws(render_tex(parse_tex(str)))
+	text = render_tex(parse_tex(str))
+	# Keep paragraphs separated to support fields like 'abstract',
+	# and clean whitespace within each paragraph separately.
+	pars = detexify.BLANK_LINE_RE.split(text.strip())
+	return detexify.PAR_SEP.join(clean_ws(p) for p in pars)
+
+detexify.BLANK_LINE_RE = re.compile(r'\n\s*\n')
+detexify.PAR_SEP = '\n\n'
 
 def title_cased(str):
 	return titlecase.titlecase(str)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -458,12 +458,12 @@ a.citation .title::after {
 .bibliography>li .bibentry .extras {
   font-size: calc(0.7 * var(--font-size));
 }
-.bibliography>li .bibentry .extras .item:not(:first-of-type)::before {
+.bibliography>li .bibentry .extras>.item:not(:first-of-type)::before {
   content: '·';
   font-weight: bold;
   padding: 0 0.5ex;
 }
-.bibliography>li .bibentry .extras .item.bibtex:not(:first-of-type)::before {
+.bibliography>li .bibentry .extras>.item.bibtex:not(:first-of-type)::before {
   padding-right: 0.4ex;
 }
 .bibliography>li .bibentry .extras a {
@@ -476,34 +476,34 @@ a.citation .title::after {
 .bibliography>li .bibentry .extras a[role=button]:hover {
   color: var(--link-hover-fg-color);
 }
-.bibliography>li .bibentry .appendix .item {
+.bibliography>li .bibentry .appendix>.item {
   display: none;
   margin: 0.6ex 0 0 0;
   padding: 0 1.5em;
   padding-bottom: 0.4ex;
   color: var(--lighter-fg-color);
 }
-.bibliography>li .bibentry .appendix div.abstract {
+.bibliography>li .bibentry .appendix>div.abstract {
   font-size: calc(0.88 * var(--font-size));
   line-height: calc(0.75 * var(--line-height));
 }
-.bibliography>li .bibentry .appendix div.abstract::before {
+.bibliography>li .bibentry .appendix>div.abstract::before {
   content: "Abstract—";
   font-style: italic;
 }
-.bibliography>li .bibentry .appendix pre.bibtex {
+.bibliography>li .bibentry .appendix>pre.bibtex {
   white-space: pre-wrap;
   padding-bottom: 0;
 }
-.bibliography>li .bibentry .appendix pre.bibtex>code {
+.bibliography>li .bibentry .appendix>pre.bibtex>code {
   display: block;
   font-size: calc(0.65 * var(--font-size));
   line-height: calc(0.6 * var(--line-height));
 }
-.bibliography>li .bibentry .extras .linkhere {
+.bibliography>li .bibentry .extras>.linkhere {
   visibility: hidden;
 }
-.bibliography>li .bibentry:hover .extras .linkhere {
+.bibliography>li .bibentry:hover .extras>.linkhere {
   visibility: visible;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -478,26 +478,24 @@ a.citation .title::after {
 }
 .bibliography>li .bibentry .appendix>.item {
   display: none;
-  margin: 0.6ex 0 0 0;
-  padding: 0 1.5em;
-  padding-bottom: 0.4ex;
+  margin: 0.6ex 0;
+  padding: 0 1em;
+  padding-bottom: 0.1ex;
   color: var(--lighter-fg-color);
 }
-.bibliography>li .bibentry .appendix>div.abstract {
-  font-size: calc(0.88 * var(--font-size));
-  line-height: calc(0.75 * var(--line-height));
+.bibliography>li .bibentry .appendix>.item:last-of-type {
+  padding-bottom: 0;
 }
 .bibliography>li .bibentry .appendix>.abstract p {
   margin: 0.6ex 0;
+  font-size: calc(0.88 * var(--font-size));
+  line-height: calc(0.75 * var(--line-height));
 }
 .bibliography>li .bibentry .appendix>.abstract p:first-of-type::before {
   content: 'Abstract\200A —\200A';
   font-style: italic;
 }
-.bibliography>li .bibentry .appendix>.bibtex {
-  padding-bottom: 0;
-}
-.bibliography>li .bibentry .appendix>.bibtex>code {
+.bibliography>li .bibentry .appendix>.bibtex code {
   display: block;
   white-space: pre-wrap;
   font-family: monospace;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -487,8 +487,11 @@ a.citation .title::after {
   font-size: calc(0.88 * var(--font-size));
   line-height: calc(0.75 * var(--line-height));
 }
-.bibliography>li .bibentry .appendix>div.abstract::before {
-  content: "Abstract—";
+.bibliography>li .bibentry .appendix>div.abstract p {
+  margin: 0.6ex 0;
+}
+.bibliography>li .bibentry .appendix>div.abstract p:first-of-type::before {
+  content: 'Abstract\200A —\200A';
   font-style: italic;
 }
 .bibliography>li .bibentry .appendix>pre.bibtex {
@@ -579,7 +582,9 @@ header>h5.meta, header>h6.meta {
   margin-top: 0.5ex;
 }
 
-p { margin: 0.8ex 0 0.8ex 0; }
+p {
+  margin: 0.8ex 0;
+}
 
 pre, code {
   font-family: Menlo, Consolas, monospace;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -476,13 +476,26 @@ a.citation .title::after {
 .bibliography>li .bibentry .extras a[role=button]:hover {
   color: var(--link-hover-fg-color);
 }
-.bibliography>li .bibentry pre.bibtex {
+.bibliography>li .bibentry .appendix .item {
   display: none;
-  white-space: pre-wrap;
   margin: 0.6ex 0 0 0;
   padding: 0 1.5em;
+  padding-bottom: 0.4ex;
+  color: var(--lighter-fg-color);
 }
-.bibliography>li .bibentry pre.bibtex>code {
+.bibliography>li .bibentry .appendix div.abstract {
+  font-size: calc(0.88 * var(--font-size));
+  line-height: calc(0.75 * var(--line-height));
+}
+.bibliography>li .bibentry .appendix div.abstract::before {
+  content: "Abstract—";
+  font-style: italic;
+}
+.bibliography>li .bibentry .appendix pre.bibtex {
+  white-space: pre-wrap;
+  padding-bottom: 0;
+}
+.bibliography>li .bibentry .appendix pre.bibtex>code {
   display: block;
   font-size: calc(0.65 * var(--font-size));
   line-height: calc(0.6 * var(--line-height));

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -487,19 +487,20 @@ a.citation .title::after {
   font-size: calc(0.88 * var(--font-size));
   line-height: calc(0.75 * var(--line-height));
 }
-.bibliography>li .bibentry .appendix>div.abstract p {
+.bibliography>li .bibentry .appendix>.abstract p {
   margin: 0.6ex 0;
 }
-.bibliography>li .bibentry .appendix>div.abstract p:first-of-type::before {
+.bibliography>li .bibentry .appendix>.abstract p:first-of-type::before {
   content: 'Abstract\200A —\200A';
   font-style: italic;
 }
-.bibliography>li .bibentry .appendix>pre.bibtex {
-  white-space: pre-wrap;
+.bibliography>li .bibentry .appendix>.bibtex {
   padding-bottom: 0;
 }
-.bibliography>li .bibentry .appendix>pre.bibtex>code {
+.bibliography>li .bibentry .appendix>.bibtex>code {
   display: block;
+  white-space: pre-wrap;
+  font-family: monospace;
   font-size: calc(0.65 * var(--font-size));
   line-height: calc(0.6 * var(--line-height));
 }

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -31,8 +31,8 @@ var bib = {
 
 	entryContentClass: "bibentry",
 	entryAppendixSelector: ".appendix",
-	entryAbstractSelector: "div.abstract",
-	entryBibtexSelector: "pre.bibtex",
+	entryAbstractSelector: ".abstract",
+	entryBibtexSelector: ".bibtex",
 	entryButtonCollapsedSign: "▸",
 	entryButtonExpandedSign: "▾",
 

--- a/static/js/bibliography.js
+++ b/static/js/bibliography.js
@@ -30,9 +30,11 @@ var bib = {
 	entryCategoryOther: "other",
 
 	entryContentClass: "bibentry",
+	entryAppendixSelector: ".appendix",
+	entryAbstractSelector: "div.abstract",
 	entryBibtexSelector: "pre.bibtex",
-	entryBibtexCollapsedSign: "▸",
-	entryBibtexExpandedSign: "▾",
+	entryButtonCollapsedSign: "▸",
+	entryButtonExpandedSign: "▾",
 
 	entryEtAlContainerClass: "etal",
 	entryEtAlContentSelector: ".content",
@@ -115,27 +117,37 @@ var bib = {
 		bib.noMatchGroup.style.display = (totalVisible > 0 ? "none" : "block");
 	},
 
-	toggleBibtexDisplay: function(button) {
+	toggleAppendixDisplay: function(button, appendixItemSelector) {
 		var entry = button;
 		while (entry && (!entry.classList.contains(bib.entryContentClass) || !entry.id))
 			entry = entry.parentNode;
 		if (!entry) return;
-		var bibtex = entry.querySelector(bib.entryBibtexSelector);
-		if (!bibtex) return;
+		var appendix = entry.querySelector(bib.entryAppendixSelector);
+		if (!appendix) return;
+		var elem = appendix.querySelector(appendixItemSelector);
+		if (!elem) return;
 
-		if (!bibtex.style.display || bibtex.style.display == "none") {
+		if (!elem.style.display || elem.style.display == "none") {
 			button.textContent = button.textContent.replace(
-				bib.entryBibtexCollapsedSign,
-				bib.entryBibtexExpandedSign
+				bib.entryButtonCollapsedSign,
+				bib.entryButtonExpandedSign
 			);
-			bibtex.style.display = "block";
+			elem.style.display = "block";
 		} else {
 			button.textContent = button.textContent.replace(
-				bib.entryBibtexExpandedSign,
-				bib.entryBibtexCollapsedSign
+				bib.entryButtonExpandedSign,
+				bib.entryButtonCollapsedSign
 			);
-			bibtex.style.display = "none";
+			elem.style.display = "none";
 		}
+	},
+
+	toggleAbstractDisplay: function(button) {
+		return bib.toggleAppendixDisplay(button, bib.entryAbstractSelector);
+	},
+
+	toggleBibtexDisplay: function(button) {
+		return bib.toggleAppendixDisplay(button, bib.entryBibtexSelector);
 	},
 
 	displayEtAlNames: function(button) {


### PR DESCRIPTION
Within the interface of a publications section, allow the user to view
the text of an entry’s abstract, if present, in the same fashion it is
already possible to view the entry’s BibTeX snippet.

Namely, add a button in the row of trailing “extra” links at the end
of each entry, pressing which toggles the visibility of the abstract.
The block containing the text of the abstract is placed right under
the entry itself (before the BibTeX snippet), and is hidden by default.
Both the abstract and the BibTeX blocks can be shown or hidden
independently from each other.