### PR TITLE
Support source code links in publication lists when the ‘code’ field is present in the corresponding BibTeX entries

### DIFF
--- a/layouts/partials/bib/entry/extras.html
+++ b/layouts/partials/bib/entry/extras.html
@@ -11,6 +11,9 @@
     <span class="{{ $class }} slidedeck"><a href="/pub/{{ . }}-slidedeck.pdf">Slide&nbsp;Deck</a></span>
   {{- end -}}
 {{- end -}}
+{{- with .entry.code -}}
+  <span class="{{ $class }} coderef"><a href="{{ . }}" target="_blank" rel="noopener">Code</a></span>
+{{- end -}}
 {{- with .entry.doi -}}
   <span class="{{ $class }} pubref"><a href="https://doi.org/{{ . }}" target="_blank" rel="noopener">Release</a></span>
 {{- end -}}

--- a/scripts/bibtex2yaml
+++ b/scripts/bibtex2yaml
@@ -86,6 +86,7 @@ BIBTEX_MULTIPAR_TEX_TAGS = {
 # a snippet for a separate entry.
 BIBTEX_SNIPPET_IGNORE_TAGS = {
 	'abstract',
+	'code',
 }
 
 # The BibTeX fields whose values are not to undergo the expansion of


### PR DESCRIPTION
Pick up URLs from the `code` fields of BibTeX entries, and render
them as links in the row of extras next to each publication entry.

The custom BibTeX `code` field is to be used solely for providing
an (external) link to the source code of the experiments published
in the paper (e.g., a link to a GitHub repository page).