### PR TITLE
Rename the custom BibTeX field for source code linking to ‘codeurl’

### DIFF
--- a/layouts/partials/bib/entry/extras.html
+++ b/layouts/partials/bib/entry/extras.html
@@ -11,7 +11,7 @@
     <span class="{{ $class }} slidedeck"><a href="/pub/{{ . }}-slidedeck.pdf">Slide&nbsp;Deck</a></span>
   {{- end -}}
 {{- end -}}
-{{- with .entry.code -}}
+{{- with .entry.codeurl -}}
   <span class="{{ $class }} coderef"><a href="{{ . }}" target="_blank" rel="noopener">Code</a></span>
 {{- end -}}
 {{- with .entry.doi -}}

--- a/scripts/bibtex2yaml
+++ b/scripts/bibtex2yaml
@@ -86,7 +86,7 @@ BIBTEX_MULTIPAR_TEX_TAGS = {
 # a snippet for a separate entry.
 BIBTEX_SNIPPET_IGNORE_TAGS = {
 	'abstract',
-	'code',
+	'codeurl',
 }
 
 # The BibTeX fields whose values are not to undergo the expansion of


### PR DESCRIPTION
Given the polysemy of the word “code”, let us make it crystal clear
that the content of the field must be a URL—by renaming it from
`code` to `codeurl`.

(And let us use the same pattern in the future: For example, if we will
be adding a new custom field for linking to videos from conference talks,
let us name the field `videourl`, not just `video`, etc.)